### PR TITLE
Added srv dependencies to pymongo allow DNS Seedlist Connection String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.5.1] - 2020-01-02
+### Changed
+- Added srv dependencies to pymongo allow DNS Seedlist Connection String Format for MongoDB.
+
 ## [3.5.0] - 2019-12-05
 ### Changed
 - Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.21.*
@@ -14,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabase/compare/v3.5.0...HEAD
+[Unreleased]: https://github.com/Colin-b/layabase/compare/v3.5.1...HEAD
+[3.5.1]: https://github.com/Colin-b/layabase/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/Colin-b/layabase/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/Colin-b/layabase/releases/tag/v3.4.0

--- a/layabase/version.py
+++ b/layabase/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.5.0"
+__version__ = "3.5.1"

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extra_requirements = {
         "pytest-cov==2.*",
     ],
     "mongo": [
-        "pymongo[tls]==3.*",
+        "pymongo[tls, srv]==3.*",
         # Used to manage date and datetime deserialization
         "iso8601==0.1.*",
     ],


### PR DESCRIPTION
### Changed
- Added srv dependencies to pymongo allow DNS Seedlist Connection String Format for MongoDB.

Closes #19 