### PR TITLE
Release 4.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 19.10b0
     hooks:
       - id: black

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.1] - 2020-04-14
+### Fixed
+- [Mongo] Fix adding field to parser adding only one level of multilevel DictColumn .
+
 ## [4.0.0] - 2020-02-11
 ### Changed
 - Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [4.0.0] - 2020-04-25
 ### Changed
-- Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*
-- model schema now returns a SQLAlchemyAutoSchema instance instead of the deprecated ModelSchema.
+- Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) version from `0.21.*` to `0.23.*`.
+- Update [black](https://pypi.org/project/black/) version from `master` to `20.10b0`.
+- model schema now returns a `SQLAlchemyAutoSchema` instance instead of the deprecated `ModelSchema`.
 - `required_on_query` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
 - `allow_comparison_signs` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
 - `interpret_star_character` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.0] - 2020-04-26
+## [4.0.0] - 2020-04-25
 ### Changed
 - Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*
 - model schema now returns a SQLAlchemyAutoSchema instance instead of the deprecated ModelSchema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.0.0] - 2020-02-11
+### Changed
+- Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*
+- model schema now returns a SQLAlchemyAutoSchema instance instead of the deprecated ModelSchema.
+- `required_on_query` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
+- `allow_comparison_signs` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
+- `interpret_star_character` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
+- Iterate over SQLAlchemy fields to find the one required on queries instead of creating a Marshmallow schema.
+
 ## [3.5.1] - 2020-01-30
 ### Fixed
 - [SQLAlchemy] Flask-RestPlus argument parsers (for GET and DELETE queries) are now restricting values in case the underlying field is of Enum type.
@@ -18,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/layabase/compare/v3.5.1...HEAD
+[Unreleased]: https://github.com/Colin-b/layabase/compare/v4.0.0...HEAD
+[4.0.0]: https://github.com/Colin-b/layabase/compare/v3.5.1...v4.0.0
 [3.5.1]: https://github.com/Colin-b/layabase/compare/v3.5.0...v3.5.1
 [3.5.0]: https://github.com/Colin-b/layabase/compare/v3.4.0...v3.5.0
 [3.4.0]: https://github.com/Colin-b/layabase/releases/tag/v3.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.0.1] - 2020-04-14
-### Fixed
-- [Mongo] Fix adding field to parser adding only one level of multilevel DictColumn .
-
-## [4.0.0] - 2020-02-11
+## [4.0.0] - 2020-04-26
 ### Changed
 - Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*
 - model schema now returns a SQLAlchemyAutoSchema instance instead of the deprecated ModelSchema.
@@ -18,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `allow_comparison_signs` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
 - `interpret_star_character` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
 - Iterate over SQLAlchemy fields to find the one required on queries instead of creating a Marshmallow schema.
+
+### Fixed
+- [Mongo] Fix adding field to parser adding only one level of multilevel DictColumn.
 
 ## [3.5.1] - 2020-01-30
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -247,21 +247,21 @@ To create a representation of a table you will need to create a [Mixin](https://
 
 ### Table
 
-You can add extra information to a column thanks to the info parameter.
+You can add extra information to a column thanks to the `layabase` key within `info` parameter.
 
 If the field should be required on queries: 
 ```python
-info={'marshmallow': {"required_on_query": True}}
+info={'layabase': {"required_on_query": True}}
 ```
 
 If `*` character in queries values should be interpreted as any characters: 
 ```python
-info={'marshmallow': {"interpret_star_character": True}}
+info={'layabase': {"interpret_star_character": True}}
 ```
 
 If the field can be queried with comparison signs such as >, <, >=, <=: 
 ```python
-info={'marshmallow': {"allow_comparison_signs": True}}
+info={'layabase': {"allow_comparison_signs": True}}
 ```
 
 When querying, provide a single value of a list of values.

--- a/layabase/_api_mongo.py
+++ b/layabase/_api_mongo.py
@@ -24,7 +24,7 @@ def _add_query_field(
         # Describe every dict column field as dot notation
         for inner_field in field._default_description_model().__dict__.values():
             if isinstance(inner_field, Column):
-                _add_query_field(parser, inner_field, f"{field.name}.")
+                _add_query_field(parser, inner_field, f"{prefix}{field.name}.")
     elif isinstance(field, ListColumn):
         # Note that List of dict or list of list might be wrongly parsed
         parser.add_argument(

--- a/layabase/_api_sqlalchemy.py
+++ b/layabase/_api_sqlalchemy.py
@@ -17,7 +17,7 @@ def _add_query_field(
 ):
     parser.add_argument(
         name,
-        required=column.info.get("marshmallow", {}).get("required_on_query", False),
+        required=column.info.get("layabase", {}).get("required_on_query", False),
         type=_get_parser_type(column),
         action="append",
         location="args",
@@ -30,7 +30,7 @@ def _get_parser_type(column: sqlalchemy.Column) -> callable:
     Return a function taking a single parameter (the value) and converting to the required field type.
     """
     column_type = column.type
-    allow_comparison_signs = column.info.get("marshmallow", {}).get(
+    allow_comparison_signs = column.info.get("layabase", {}).get(
         "allow_comparison_signs", False
     )
     if isinstance(column_type, sqlalchemy.String) or isinstance(

--- a/layabase/version.py
+++ b/layabase/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.0"
+__version__ = "3.5.1"

--- a/layabase/version.py
+++ b/layabase/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.0"
+__version__ = "4.0.1"

--- a/layabase/version.py
+++ b/layabase/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "3.5.1"
+__version__ = "4.0.0"

--- a/layabase/version.py
+++ b/layabase/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "4.0.1"
+__version__ = "4.0.0"

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_requirements = {
     "sqlalchemy": [
         "marshmallow==3.*",
         "SQLAlchemy==1.*",
-        "marshmallow_sqlalchemy==0.22.*",
+        "marshmallow_sqlalchemy==0.23.*",
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ extra_requirements = {
     "sqlalchemy": [
         "marshmallow==3.*",
         "SQLAlchemy==1.*",
-        "marshmallow_sqlalchemy==0.21.*",
+        "marshmallow_sqlalchemy==0.22.*",
     ],
 }
 

--- a/tests/test_mongo_controller_date.py
+++ b/tests/test_mongo_controller_date.py
@@ -229,7 +229,7 @@ def test_post_datetime_for_a_date_is_valid(controller):
     ) == {
         "key": "my_key1",
         "date_str": "2017-05-01",
-        "datetime_str": "2017-05-30T01:05:45",
+        "datetime_str": "2017-05-30T01:05:45+00:00",
     }
 
 

--- a/tests/test_mongo_controller_dict_in_dict.py
+++ b/tests/test_mongo_controller_dict_in_dict.py
@@ -82,6 +82,20 @@ def test_get_with_dot_notation_multi_level_is_valid(controller):
     ] == controller.get({"dict_field.first_key.inner_key1": EnumTest.Value1})
 
 
+def test_get_and_delete_parsers_contains_multi_level_dot_notation_fields(controller):
+    assert {
+        "key",
+        "dict_field.first_key.inner_key1",
+        "dict_field.first_key.inner_key2",
+        "dict_field.second_key",
+    }.issubset({arg.name for arg in controller.query_delete_parser.args})
+
+    assert {
+        "dict_field.first_key.inner_key1",
+        "dict_field.first_key.inner_key2",
+    }.issubset({arg.name for arg in controller.query_get_parser.args})
+
+
 @pytest.fixture
 def app(controller):
     application = flask.Flask(__name__)

--- a/tests/test_mongo_controller_dict_in_dict.py
+++ b/tests/test_mongo_controller_dict_in_dict.py
@@ -1,5 +1,7 @@
 import enum
 
+import flask
+import flask_restplus
 import pytest
 
 import layabase
@@ -78,3 +80,277 @@ def test_get_with_dot_notation_multi_level_is_valid(controller):
             "key": "my_key",
         }
     ] == controller.get({"dict_field.first_key.inner_key1": EnumTest.Value1})
+
+
+@pytest.fixture
+def app(controller):
+    application = flask.Flask(__name__)
+    application.testing = True
+    api = flask_restplus.Api(application)
+    namespace = api.namespace("Test", path="/")
+
+    controller.namespace(namespace)
+
+    @namespace.route("/test")
+    class TestResource(flask_restplus.Resource):
+        @namespace.expect(controller.query_get_parser)
+        @namespace.marshal_with(controller.get_response_model)
+        def get(self):
+            return []
+
+        @namespace.expect(controller.json_post_model)
+        def post(self):
+            return []
+
+        @namespace.expect(controller.json_put_model)
+        def put(self):
+            return []
+
+        @namespace.expect(controller.query_delete_parser)
+        def delete(self):
+            return []
+
+    return application
+
+
+def test_open_api_definition(client):
+    response = client.get("/swagger.json")
+    assert response.json == {
+        "swagger": "2.0",
+        "basePath": "/",
+        "paths": {
+            "/test": {
+                "put": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "put_test_resource",
+                    "parameters": [
+                        {
+                            "name": "payload",
+                            "required": True,
+                            "in": "body",
+                            "schema": {
+                                "$ref": "#/definitions/TestCollection_PutRequestModel"
+                            },
+                        }
+                    ],
+                    "tags": ["Test"],
+                },
+                "get": {
+                    "responses": {
+                        "200": {
+                            "description": "Success",
+                            "schema": {
+                                "$ref": "#/definitions/TestCollection_GetResponseModel"
+                            },
+                        }
+                    },
+                    "operationId": "get_test_resource",
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.first_key.inner_key1",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.first_key.inner_key2",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.second_key",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "limit",
+                            "in": "query",
+                            "type": "integer",
+                            "minimum": 0,
+                            "exclusiveMinimum": True,
+                        },
+                        {
+                            "name": "offset",
+                            "in": "query",
+                            "type": "integer",
+                            "minimum": 0,
+                        },
+                        {
+                            "name": "X-Fields",
+                            "in": "header",
+                            "type": "string",
+                            "format": "mask",
+                            "description": "An optional fields mask",
+                        },
+                    ],
+                    "tags": ["Test"],
+                },
+                "delete": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "delete_test_resource",
+                    "parameters": [
+                        {
+                            "name": "key",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.first_key.inner_key1",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.first_key.inner_key2",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "collectionFormat": "multi",
+                        },
+                        {
+                            "name": "dict_field.second_key",
+                            "in": "query",
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "collectionFormat": "multi",
+                        },
+                    ],
+                    "tags": ["Test"],
+                },
+                "post": {
+                    "responses": {"200": {"description": "Success"}},
+                    "operationId": "post_test_resource",
+                    "parameters": [
+                        {
+                            "name": "payload",
+                            "required": True,
+                            "in": "body",
+                            "schema": {
+                                "$ref": "#/definitions/TestCollection_PostRequestModel"
+                            },
+                        }
+                    ],
+                    "tags": ["Test"],
+                },
+            }
+        },
+        "info": {"title": "API", "version": "1.0"},
+        "produces": ["application/json"],
+        "consumes": ["application/json"],
+        "tags": [{"name": "Test"}],
+        "definitions": {
+            "TestCollection_PutRequestModel": {
+                "required": ["dict_field"],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "readOnly": False,
+                        "example": "sample key",
+                    },
+                    "dict_field": {
+                        "readOnly": False,
+                        "default": {
+                            "first_key": {"inner_key1": None, "inner_key2": None},
+                            "second_key": None,
+                        },
+                        "example": {
+                            "first_key": {"inner_key1": "Value1", "inner_key2": 1},
+                            "second_key": 1,
+                        },
+                        "allOf": [{"$ref": "#/definitions/first_key_second_key"}],
+                    },
+                },
+                "type": "object",
+            },
+            "first_key_second_key": {
+                "required": ["first_key"],
+                "properties": {
+                    "first_key": {
+                        "readOnly": False,
+                        "default": {"inner_key1": None, "inner_key2": None},
+                        "example": {"inner_key1": "Value1", "inner_key2": 1},
+                        "allOf": [{"$ref": "#/definitions/inner_key1_inner_key2"}],
+                    },
+                    "second_key": {"type": "integer", "readOnly": False, "example": 1},
+                },
+                "type": "object",
+            },
+            "inner_key1_inner_key2": {
+                "properties": {
+                    "inner_key1": {
+                        "type": "string",
+                        "readOnly": False,
+                        "example": "Value1",
+                        "enum": ["Value1", "Value2"],
+                    },
+                    "inner_key2": {"type": "integer", "readOnly": False, "example": 1},
+                },
+                "type": "object",
+            },
+            "TestCollection_PostRequestModel": {
+                "required": ["dict_field"],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "readOnly": False,
+                        "example": "sample key",
+                    },
+                    "dict_field": {
+                        "readOnly": False,
+                        "default": {
+                            "first_key": {"inner_key1": None, "inner_key2": None},
+                            "second_key": None,
+                        },
+                        "example": {
+                            "first_key": {"inner_key1": "Value1", "inner_key2": 1},
+                            "second_key": 1,
+                        },
+                        "allOf": [{"$ref": "#/definitions/first_key_second_key"}],
+                    },
+                },
+                "type": "object",
+            },
+            "TestCollection_GetResponseModel": {
+                "required": ["dict_field"],
+                "properties": {
+                    "key": {
+                        "type": "string",
+                        "readOnly": False,
+                        "example": "sample key",
+                    },
+                    "dict_field": {
+                        "readOnly": False,
+                        "default": {
+                            "first_key": {"inner_key1": None, "inner_key2": None},
+                            "second_key": None,
+                        },
+                        "example": {
+                            "first_key": {"inner_key1": "Value1", "inner_key2": 1},
+                            "second_key": 1,
+                        },
+                        "allOf": [{"$ref": "#/definitions/first_key_second_key"}],
+                    },
+                },
+                "type": "object",
+            },
+        },
+        "responses": {
+            "ParseError": {"description": "When a mask can't be parsed"},
+            "MaskError": {"description": "When any error occurs on mask"},
+        },
+    }

--- a/tests/test_mongo_controller_dict_in_dict.py
+++ b/tests/test_mongo_controller_dict_in_dict.py
@@ -84,10 +84,8 @@ def test_get_with_dot_notation_multi_level_is_valid(controller):
 
 def test_get_and_delete_parsers_contains_multi_level_dot_notation_fields(controller):
     assert {
-        "key",
         "dict_field.first_key.inner_key1",
         "dict_field.first_key.inner_key2",
-        "dict_field.second_key",
     }.issubset({arg.name for arg in controller.query_delete_parser.args})
 
     assert {

--- a/tests/test_mongo_controller_index_with_id.py
+++ b/tests/test_mongo_controller_index_with_id.py
@@ -35,7 +35,7 @@ def test_post_many_with_same_unique_index_is_invalid(controller):
         "": [
             "{'writeErrors': [{'index': 1, 'code': 11000, 'errmsg': 'E11000 "
             "Duplicate Key Error', 'op': {'unique_key': 'test', 'non_unique_key': "
-            "datetime.datetime(2017, 1, 1, 0, 0), '_id': "
+            "datetime.datetime(2017, 1, 1, 0, 0, tzinfo=datetime.timezone.utc), '_id': "
             "ObjectId('222222222222222222222222')}}], 'nInserted': 1}"
         ]
     }

--- a/tests/test_sqlalchemy_controller_comparison_signs.py
+++ b/tests/test_sqlalchemy_controller_comparison_signs.py
@@ -17,16 +17,16 @@ def controller():
         id = sqlalchemy.Column(sqlalchemy.String, primary_key=True)
 
         int_value = sqlalchemy.Column(
-            sqlalchemy.Integer, info={"marshmallow": {"allow_comparison_signs": True}}
+            sqlalchemy.Integer, info={"layabase": {"allow_comparison_signs": True}}
         )
         float_value = sqlalchemy.Column(
-            sqlalchemy.Float, info={"marshmallow": {"allow_comparison_signs": True}}
+            sqlalchemy.Float, info={"layabase": {"allow_comparison_signs": True}}
         )
         date_value = sqlalchemy.Column(
-            sqlalchemy.Date, info={"marshmallow": {"allow_comparison_signs": True}}
+            sqlalchemy.Date, info={"layabase": {"allow_comparison_signs": True}}
         )
         datetime_value = sqlalchemy.Column(
-            sqlalchemy.DateTime, info={"marshmallow": {"allow_comparison_signs": True}}
+            sqlalchemy.DateTime, info={"layabase": {"allow_comparison_signs": True}}
         )
 
     controller = layabase.CRUDController(TestTable)

--- a/tests/test_sqlalchemy_controller_like_operator.py
+++ b/tests/test_sqlalchemy_controller_like_operator.py
@@ -12,7 +12,7 @@ def controller():
         key = sqlalchemy.Column(
             sqlalchemy.String,
             primary_key=True,
-            info={"marshmallow": {"interpret_star_character": True}},
+            info={"layabase": {"interpret_star_character": True}},
         )
 
     controller = layabase.CRUDController(TestTable)

--- a/tests/test_sqlalchemy_controller_query_required.py
+++ b/tests/test_sqlalchemy_controller_query_required.py
@@ -16,7 +16,7 @@ def controller():
         mandatory = sqlalchemy.Column(
             sqlalchemy.Integer,
             nullable=False,
-            info={"marshmallow": {"required_on_query": True}},
+            info={"layabase": {"required_on_query": True}},
         )
 
     controller = layabase.CRUDController(TestTable)


### PR DESCRIPTION
### Changed
- Update [marshmallow_sqlalchemy](https://marshmallow-sqlalchemy.readthedocs.io/en/latest/changelog.html) to version 0.22.*
- model schema now returns a SQLAlchemyAutoSchema instance instead of the deprecated ModelSchema.
- `required_on_query` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
- `allow_comparison_signs` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
- `interpret_star_character` should be set within `layabase` key inside info (was linked to `marshmallow` key previously).
- Iterate over SQLAlchemy fields to find the one required on queries instead of creating a Marshmallow schema.
