### PR TITLE
Add test for MongoDB ping with extended details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added test for MongoDB ping with extended details
 
 ## [4.0.0.dev2] - 2020-10-08
 ### Changed


### PR DESCRIPTION
Some MongoDB clusters return advanced details like cluster time and signature with object types that are not JSON-serializable.

You're probably going to manipulate the response object here:

```python
def _check(base: pymongo.database.Database) -> (str, dict):
    try:
        response = base.command("ping")
        return (
            "pass",
            {
                f"{base.name}:ping": {
                    "componentType": "datastore",
                    "observedValue": response,
                    "status": "pass",
                    "time": datetime.datetime.utcnow().isoformat(),
                }
            },
        )
```

but please notice that the `response` object is used internally by pymongo for its internal health check, so changing that object will break pymongo, to solve that I needed to copy the `response` object before modyfing it:

```python
# this will break pymongo:
response["$clusterTime"]["clusterTime"] = response["$clusterTime"]["clusterTime"].as_datetime().isoformat()
```